### PR TITLE
feat: 新增 setSavedItems 功能以從 localStorage 加載購物車項目，並在登錄時保存用戶購物車資料

### DIFF
--- a/src/components/Header/HeaderPin.jsx
+++ b/src/components/Header/HeaderPin.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import Button from "../Button/Button";
 import { loginout } from "../../features/user/userSlice";
 import { isSearch } from "../../features/ui/uiSlice";
+import { cleanCart } from "../../features/cart/cartSlice";
 import { search } from "../../features/products/productsSlice";
 import { useDispatch, useSelector } from "react-redux";
 import { useLocation, useNavigate } from "react-router-dom";
@@ -65,6 +66,7 @@ const HeaderPin = ({ handleToggle }) => {
                     label="Logout"
                     onClick={() => {
                       dispatch(loginout());
+                      dispatch(cleanCart());
                       navigate("/");
                     }}
                   />

--- a/src/components/LoginForm/LoginForm.jsx
+++ b/src/components/LoginForm/LoginForm.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { mockLoginAPI } from "../../features/user/mockAuthAPI.js";
 import { login } from "../../features/user/userSlice.js";
+import { setSavedItems } from "../../features/cart/cartSlice.js";
 import Button from "../Button/Button.jsx";
 import FormInputContainer from "./FormInputContainer.jsx";
 
@@ -40,7 +41,7 @@ const LoginForm = () => {
       const userData = await mockLoginAPI({ email, password });
       // 確認回傳資料沒有password
       dispatch(login(userData)); // 將資料存入 Redux
-
+      dispatch(setSavedItems(userData.email)); // 將購物車資料存入 Redux
       if (userData.role === "menber") {
         // 根據取得的 userDate身分去做個別的導入頁面
         navigate("/products");

--- a/src/features/cart/cartSlice.js
+++ b/src/features/cart/cartSlice.js
@@ -20,6 +20,15 @@ const cartSlice = createSlice({
   name: "cart",
   initialState,
   reducers: {
+    setSavedItems(state, action) {
+      const userEmail = action.payload;
+      const savedItems = localStorage.getItem(`Cart_${userEmail}`);
+      if (savedItems) {
+        state.items = JSON.parse(savedItems);
+      } else {
+        state.items = [];
+      }
+    },
     // 新增商品
     addItem(state, action) {
       const { product, quantity, deliveryMethod } = action.payload;
@@ -92,6 +101,7 @@ const cartSlice = createSlice({
 });
 
 export const {
+  setSavedItems,
   addItem,
   removeItem,
   cleanCart,


### PR DESCRIPTION
當切換不同使用者帳號時，購物車內容會與前一位使用者的資料重疊

- 登入時：
系統會依照當前登入使用者的帳號（以電子郵件作為 key），自 localStorage 中讀取並載入對應的購物車內容。若該使用者尚未有任何資料，則會自動建立一個空的購物車陣列，確保後續操作不會發生錯誤。

- 登出時：
系統會清空目前使用者的購物車狀態，避免與下一位登入者的內容混淆。這樣一來，每位使用者在切換帳號後，皆能獨立擁有各自的購物車資料。